### PR TITLE
refactor TrainConfig, save HF model by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ python scripts/finetune.py \
   --num_workers_dataloader 0 \
   --max_steps 10 \
   --model_name "yujiepan/llama-2-tiny-random" \
-  --dist_checkpoint_root_folder "checkpoints" \
-  --dist_checkpoint_folder "my_model_dir" \
+  --save_checkpoint_root_dir "checkpoints" \
+  --run_name "my_model_dir" \
   --save_model \
   --save_optimizer
 ```
@@ -175,8 +175,8 @@ python scripts/finetune.py \
   --num_workers_dataloader 0 \
   --max_steps 10 \
   --model_name "yujiepan/llama-2-tiny-random" \
-  --dist_checkpoint_root_folder "checkpoints" \
-  --dist_checkpoint_folder "my_model_dir" \
+  --save_checkpoint_root_dir "checkpoints" \
+  --run_name "my_model_dir" \
   --save_model \
   --save_optimizer
 ```

--- a/scripts/finetune.py
+++ b/scripts/finetune.py
@@ -407,6 +407,7 @@ def main(
     # Start the training process
     results = train(
         model,
+        tokenizer,
         train_dataloader,
         eval_dataloader,
         optimizer,

--- a/scripts/tests/train_tiny_fsdp_test.sh
+++ b/scripts/tests/train_tiny_fsdp_test.sh
@@ -18,8 +18,8 @@ python scripts/finetune.py \
   --warmup_steps 4 \
   --num_workers_dataloader 8 \
   --max_steps 16 \
-  --dist_checkpoint_root_folder "checkpoints" \
-  --dist_checkpoint_folder "fsdp_test" \
+  --save_checkpoint_root_dir "checkpoints" \
+  --run_name "fsdp_test" \
   --save_model \
   --save_optimizer \
   --enable_fsdp \

--- a/scripts/tests/train_tiny_local_peft_test.sh
+++ b/scripts/tests/train_tiny_local_peft_test.sh
@@ -24,12 +24,12 @@ python scripts/finetune.py \
   --r 8 \
   --lora_alpha 32 \
   --model_name "yujiepan/llama-2-tiny-random" \
-  --dist_checkpoint_root_folder "checkpoints" \
-  --dist_checkpoint_folder "tiny_trainer" \
+  --save_checkpoint_root_dir "checkpoints" \
+  --run_name "tiny_trainer" \
   --save_model \
   --save_optimizer
 
-# the model is saved at <dist_checkpoint_root_folder>/<dist_checkpoint_folder>-<model_name>
+# the model is saved at <save_checkpoint_root_dir>/<run_name>-<model_name>
 OUTPUT_DIR="checkpoints/tiny_trainer-yujiepan/llama-2-tiny-random/"
 echo "got the following output files at ${OUTPUT_DIR}:"
 ls $OUTPUT_DIR

--- a/scripts/tests/train_tiny_local_test.sh
+++ b/scripts/tests/train_tiny_local_test.sh
@@ -18,16 +18,15 @@ python scripts/finetune.py \
   --warmup_steps 1 \
   --num_workers_dataloader 0 \
   --batch_size_training 2 \
-  --max_steps 10 \
+  --max_steps 3 \
   --model_name "yujiepan/llama-2-tiny-random" \
-  --dist_checkpoint_root_folder "checkpoints" \
-  --dist_checkpoint_folder "tiny_trainer" \
+  --save_checkpoint_root_dir "checkpoints" \
+  --run_name "tiny_trainer" \
   --save_model \
   --save_optimizer \
   --serializer_cls "BasicSerializerV2"
 
-# the model is saved at <dist_checkpoint_root_folder>/<dist_checkpoint_folder>-<model_name>
-OUTPUT_DIR="checkpoints/tiny_trainer-yujiepan/llama-2-tiny-random/"
+OUTPUT_DIR="checkpoints/tiny_trainer-llama-2-tiny-random/"
 echo "got the following output files at ${OUTPUT_DIR}:"
 ls $OUTPUT_DIR
 


### PR DESCRIPTION
Refactor TrainConfig to remove dependency on (buggy) llama_recipes train_config class; use HF .save_pretrained() at the end of training by default.

Also introduce some changes to the class:
* introduce save_checkpoint_root_dir and run_name which are used to construct a new output_dir property
* move make_save_folder_name into a TrainConfig class method
* update the various scripts to use the correct new parameter names
* set TrainConfig to use llama 3 by default
* save a HF model and tokenizer at the end of training